### PR TITLE
Changes in input "adu" and fprintf from "info"

### DIFF
--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -107,7 +107,7 @@ skip=0;
 %Set default parameters
 params={'x','fname','Fs','bit_res','adu','info','gain','sg_name','baseline','isint'};
 Fs=1;
-adu=[];
+adu={};
 info=[];
 isint=0;
 %Use cell array for baseline and gain in case of empty conditions
@@ -202,7 +202,7 @@ for m=1:M+1
 end
 
 if(~isempty(info))
-    count=fprintf(fid,'#%s',info);
+    count=cellfun(@(x) fprintf(fid,'#%s\n',x),info);
 end
 
 if(nargout==1)

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -141,6 +141,9 @@ if(isempty(sg_name))
 end
 if(isempty(adu))
     adu=repmat({'V'},[M 1]);
+elseif length(adu)<M
+    adu=repmat(adu{:},[M 1]);
+end
 end
 if ~isempty(setdiff(bit_res,bit_res_suport))
     error(['Bit res should be any of: ' num2str(bit_res_suport)]);

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -29,11 +29,11 @@ function [varargout]=mat2wfdb(varargin)
 %          process. Use this options if you want to have a standard gain and quantization
 %          process for all signals in a dataset (the function will not attempt to quantitized
 %          individual waveforms based on their individual range and baseline).
-%baseline   -(Optional) Offset (ADC zero) Mx1 array of integers that represents the amplitude (sample
-%           value) that would be observed if the analog signal present at the ADC inputs had a
-%           level that fell exactly in the middle of the input range of the ADC.
 % sg_name -(Optional) Cell array of strings describing signal names.
 %
+% baseline   -(Optional) Offset (ADC zero) Mx1 array of integers that represents the amplitude (sample
+%           value) that would be observed if the analog signal present at the ADC inputs had a
+%           level that fell exactly in the middle of the input range of the ADC.
 % isint  -(Optional) Logical value (default=0). Use this option if you know
 %           the signal is already quantitized, and you want to remove round-off
 %           error by setting the original values to integers prior to fixed

--- a/mcode/wfdb2mat.m
+++ b/mcode/wfdb2mat.m
@@ -1,4 +1,4 @@
-function varargout=wfdb2mat(varargin)
+function wfdb2mat(varargin)
 %
 % wfdm2mat(recordName,signaList,N,N0)
 %


### PR DESCRIPTION
When attempting to use function with an empty "adu", error occurs in line 129 (trying to split an empty double)

Line 205 was modified to print to file multiple lines of string.