### PR TITLE
Improve usability of mat2wfdb

### DIFF
--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -132,10 +132,14 @@ if(isempty(gain))
     gain=cell(M,1); %Generate empty cells as default
 elseif(length(gain)==1)
     gain=repmat(gain,[M 1]);
-    gain=num2cell(gain);
 else
     gain=gain;
 end
+% ensure gain is a cell array
+if isnumeric(gain)
+    gain=num2cell(gain);
+end
+
 if(isempty(sg_name))
     sg_name=repmat({''},[M 1]);
 end
@@ -149,6 +153,9 @@ if(isempty(baseline))
     baseline=cell(M,1); %Generate empty cells as default
 elseif(length(baseline)==1)
     baseline=repmat(baseline,[M 1]);
+end
+% ensure baseline is a cell array
+if isnumeric(baseline)
     baseline=num2cell(baseline);
 end
 

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -27,6 +27,9 @@ function [varargout]=mat2wfdb(varargin)
 %            - Cell array of strings, where the total units entered has to equal M 
 %            (number of channels).
 % info    -(Optional)  String that will be added to the comment section of the header file.
+%           For multi-lined comments, use a cell array of strings. Each
+%           cell will be output on a new line. Note that comments in the
+%           header file are automatically prefixed with a pound symbol (#)
 % gain    -(Optional) Scalar, if provided, no automatic scaling will be applied before the
 %          quantitzation of the signal. If a gain is passed,  in will be the same one set
 %          on the header file. The signal will be scaled by this gain prior to the quantization
@@ -226,7 +229,13 @@ for m=1:M+1
 end
 
 if(~isempty(info))
-    count=fprintf(fid,'#%s',info);
+    if ischar(info)
+        fprintf(fid,'#%s',info);
+    elseif iscell(info)
+        for m=1:numel(info)
+            fprintf(fid,'#%s',info{m});
+        end
+    end
 end
 
 if(nargout==1)


### PR DESCRIPTION
Just some various minor edits to mat2wfdb, specifically:

* allowing `adu` to be entered as a string ('V/mV/NU/NU'), a cell array ({'V','mV','NU','NU'})
* allowing `gain` and `baseline` to be entered as vectors
* allowing multi-line comments to be entered (as a cell array)

Also added comments to the header clarifying these changes.