### PR TITLE
Update source packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ For a list of available databases accessible through the WFDB Toolbox, see:
 
 http://physionet.org/physiobank/database/DBS
 
-## Installing from the PhysioNet
+## Installing from PhysioNet
 
-To check out and install from the PhysioNet using MATLAB, run the following commands:
+To check out and install from PhysioNet using MATLAB, run the following commands:
 
 ```
 [old_path]=which('rdsamp');if(~isempty(old_path)) rmpath(old_path(1:end-8)); end
-wfdb_url='http://physionet.org/physiotools/matlab/wfdb-app-matlab/wfdb-app-toolbox-0-10-0.zip';
-[filestr,status] = urlwrite(wfdb_url,'wfdb-app-toolbox-0-10-0.zip');%Octave users may have to download manually
+wfdb_url='https://physionet.org/physiotools/matlab/wfdb-app-matlab/wfdb-app-toolbox-0-10-0.zip';
+[filestr,status] = urlwrite(wfdb_url,'wfdb-app-toolbox-0-10-0.zip');
 unzip('wfdb-app-toolbox-0-10-0.zip');
 cd mcode
 addpath(pwd);savepath
@@ -46,9 +46,18 @@ addpath(pwd);savepath
 ```
 ## Checking out and installing from the trunk
 
-1) Clone repo to you local system
-2) Run "build-toolbox" shell script to build all the necessary binaries (ie, you might need to install all the cross-compiler
-tools necessary to build the binaries for Mac OS X and Windows). 
+Building the toolbox requires:
+- The GNU C compiler (GCC)
+- The GNU Fortran compiler (gfortran)
+- GNU Make
+- GNU Autoconf
+- GNU Libtool
+- Java Development Kit
+- Ant
+
+To build the toolbox, simply run 'make' in the top-level directory.
+This will automatically download various dependencies from PhysioNet
+and elsewhere (see 'mcode/nativelibs/Makefile' for details.)
 
 ## Reference & Toolbox Technical Overview
 

--- a/mcode/nativelibs/Makefile
+++ b/mcode/nativelibs/Makefile
@@ -24,12 +24,12 @@ CURL_ARCHIVE=$(CURL_PKG).tar.gz
 CURL_SOURCE=http://curl.haxx.se/download/$(CURL_ARCHIVE)
 CURL_SHA256=7ce35f207562674e71dbada6891b37e3f043c1e7a82915cb9c2a17ad3a9d659b
 
-WFDB_PKG=wfdb-10.5.25
+WFDB_PKG=wfdb-10.6.0
 #WFDB_ARCHIVE=$(WFDB_PKG).tar.gz
 #WFDB_SOURCE=http://www.physionet.org/physiotools/archives/wfdb-10.5/$(WFDB_ARCHIVE)
-WFDB_ARCHIVE=wfdb-10.5.25pre1.tar.gz
+WFDB_ARCHIVE=wfdb-10.6.0pre1.tar.gz
 WFDB_SOURCE=http://www.physionet.org/physiotools/beta/$(WFDB_ARCHIVE)
-WFDB_SHA256=37fb59c04f5b36d4146e3cb71d28a59108581271feb079631cd922febe21fa73
+WFDB_SHA256=5f2afaac65e6e77a56baf20a12e8a1431bc02e0e2f227f4ba4ca7c529b3289ca
 WFDB_MAJOR=10
 
 ECGPUWAVE_PKG=ecgpuwave-1.3.3
@@ -245,8 +245,6 @@ installclean-curl:
 ################################################################
 ## WFDB (requires libcurl)
 
-# FIXME: configure --without-xview; parallel make (10.5.25)
-
 clean-wfdb:
 	rm -rf $(BUILD_DIR)/$(WFDB_PKG)
 	rm -f $(BUILD_DIR)/wfdb.isconfig
@@ -264,6 +262,7 @@ $(BUILD_DIR)/wfdb.isconfig: $(WFDB_ARCHIVE) $(BUILD_DIR)/curl.isbuilt
 	  ./configure $(configure_args) \
 	    --prefix=$(prefix) \
 	    --libdir=$(libdir) \
+	    --without-xview \
 	    --with-libcurl )
 	sed -e "s/ DBDIR//" -i $(BUILD_DIR)/$(WFDB_PKG)/lib/wfdblib.h0
 	sed -e "s, /usr/database,," -i $(BUILD_DIR)/$(WFDB_PKG)/checkpkg/expected/lcheck.log-NETFILES
@@ -271,9 +270,9 @@ $(BUILD_DIR)/wfdb.isconfig: $(WFDB_ARCHIVE) $(BUILD_DIR)/curl.isbuilt
 $(BUILD_DIR)/wfdb.isbuilt: PATH:=$(buildbindir):$(PATH)
 $(BUILD_DIR)/wfdb.isbuilt: $(BUILD_DIR)/wfdb.isconfig
 	( cd $(BUILD_DIR)/$(WFDB_PKG) && \
-	  make -j1 install CC="$(CC) -I$(includedir) -L$(libdir)" \
+	  make install CC="$(CC) -I$(includedir) -L$(libdir)" \
 	    RPATHFLAGS= )
-	[ -n "$(nocheck)" ] || ( cd $(BUILD_DIR)/$(WFDB_PKG) && make -j1 check )
+	[ -n "$(nocheck)" ] || ( cd $(BUILD_DIR)/$(WFDB_PKG) && make check )
 	rm -f $(bindir)/psfd \
 	      $(bindir)/hrmem \
 	      $(bindir)/hrfft \

--- a/mcode/nativelibs/Makefile
+++ b/mcode/nativelibs/Makefile
@@ -19,10 +19,10 @@ host=custom
 
 #Package names and versions
 
-CURL_PKG=curl-7.56.0
+CURL_PKG=curl-7.57.0
 CURL_ARCHIVE=$(CURL_PKG).tar.gz
 CURL_SOURCE=http://curl.haxx.se/download/$(CURL_ARCHIVE)
-CURL_SHA256=f1bc17a7e5662dbd8d4029750a6dbdb72a55cf95826a270ab388b05075526104
+CURL_SHA256=7ce35f207562674e71dbada6891b37e3f043c1e7a82915cb9c2a17ad3a9d659b
 
 WFDB_PKG=wfdb-10.5.25
 #WFDB_ARCHIVE=$(WFDB_PKG).tar.gz


### PR DESCRIPTION
Update curl to 7.57.0 and wfdb to 10.6.0pre1.

curl includes some security fixes which probably do not affect the toolbox.

wfdb includes a number of security fixes as well as other bug fixes.  Some that may be relevant include:
- better calculation of physical values in edf files
- better calculation of everything in multisegment records
- correctly reading long-duration / high-precision annotation files (e.g. the upcoming mimic3wdb annotations) from 32-bit applications (e.g. windows)
- correctly writing long-duration / high-precision annotation files from 64-bit applications
- sortann correctly preserves resolution
- xform clipping mode fixed