### PR TITLE
mat2wfdb: include line feed following a single info string.

### DIFF
--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -288,7 +288,7 @@ end
 
 if(~isempty(info))
     if ischar(info)
-        fprintf(fid,'#%s',info);
+        fprintf(fid,'#%s\n',info);
     elseif iscell(info)
         for m=1:numel(info)
             fprintf(fid,'#%s\n',info{m});


### PR DESCRIPTION
Although not strictly necessary, it is polite to end header files with
a line feed.