### PR TITLE
Update libcurl to 7.64.0.

### DIFF
--- a/mcode/nativelibs/Makefile
+++ b/mcode/nativelibs/Makefile
@@ -19,10 +19,10 @@ host=custom
 
 #Package names and versions
 
-CURL_PKG=curl-7.58.0
+CURL_PKG=curl-7.64.0
 CURL_ARCHIVE=$(CURL_PKG).tar.gz
 CURL_SOURCE=http://curl.haxx.se/download/$(CURL_ARCHIVE)
-CURL_SHA256=cc245bf9a1a42a45df491501d97d5593392a03f7b4f07b952793518d97666115
+CURL_SHA256=cb90d2eb74d4e358c1ed1489f8e3af96b50ea4374ad71f143fa4595e998d81b5
 
 WFDB_PKG=wfdb-10.6.0
 WFDB_ARCHIVE=$(WFDB_PKG).tar.gz


### PR DESCRIPTION
This has some security fixes:
https://curl.haxx.se/docs/CVE-2018-16890.html
https://curl.haxx.se/docs/CVE-2019-3822.html