### PR TITLE
Improvements for 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check:
 	 "pkg load signal; \
 	  addpath('$$mcodedir'); \
 	  confirm_recursive_rmdir(0); \
-	  BatchTest"
+	  BatchTest; exit(total_failed > 0)"
 
 jartest: mcode/$(JAR7_NAME) unit-test.zip
 	cd mcode; \

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,15 @@ check:
 	  confirm_recursive_rmdir(0); \
 	  BatchTest; exit(total_failed > 0)"
 
+check-%:
+	set -e; unset DISPLAY; mcodedir=`pwd`/mcode; \
+	cd UnitTests && octave -q --eval \
+	 "pkg load signal; \
+	  addpath('$$mcodedir'); \
+	  confirm_recursive_rmdir(0); \
+	  [tests,pass,perf]=test_$*(); \
+	  exit(tests < pass)"
+
 jartest: mcode/$(JAR7_NAME) unit-test.zip
 	cd mcode; \
 	java -cp $(JAR7_NAME) org.physionet.wfdb.Wfdbexec rdsamp -r mitdb/100 -t s5


### PR DESCRIPTION
First, ensure that 'make check' will actually exit with non-zero
status if any of the tests fail.

Second, add a rule for quickly running a single unit test.