### PR TITLE
Avoid use of javah

### DIFF
--- a/dependencies/jni/Makefile.in
+++ b/dependencies/jni/Makefile.in
@@ -21,7 +21,6 @@ WFDB_CFLAGS = @WFDB_CFLAGS@
 WFDB_LIBS = @WFDB_LIBS@
 
 JAVA = @JAVA@
-JAVAH = @JAVAH@
 
 classdir = $(srcdir)/../../bin/classes
 
@@ -44,17 +43,13 @@ librdsampjni.la: rdsampjni.lo
 	  rdsampjni.lo -o librdsampjni.la \
 	  $(WFDB_LIBS) $(LIBS)
 
-rdsampjni.lo: rdsampjni.c org_physionet_wfdb_jni_Rdsamp.h
+rdsampjni.lo: rdsampjni.c
 	$(LIBTOOL) --mode=compile $(CC) $(CFLAGS) $(CPPFLAGS) \
 	  $(DEFS) $(WFDB_CFLAGS) $(JNI_CFLAGS) -I. \
 	  -c $(srcdir)/rdsampjni.c
 
-org_physionet_wfdb_jni_Rdsamp.h: $(classdir)/org/physionet/wfdb/jni/Rdsamp.class
-	$(JAVAH) -classpath $(classdir) org.physionet.wfdb.jni.Rdsamp
-
 clean:
 	$(LIBTOOL) --mode=clean rm -f *.la *.lo
-	rm -f org_physionet_wfdb_jni_Rdsamp.h
 	rm -rf test.jar nativelibs 100s.out
 
 distclean: clean

--- a/dependencies/jni/configure.ac
+++ b/dependencies/jni/configure.ac
@@ -12,9 +12,9 @@ AC_DISABLE_STATIC
 AC_PROG_LIBTOOL
 
 AC_ARG_VAR([JAVA], [Java interpreter])
-AC_ARG_VAR([JAVAH], [JNI header generator])
+AC_ARG_VAR([JAVAC], [Java compiler])
 AC_CHECK_PROGS([JAVA], [java])
-AC_CHECK_PROGS([JAVAH], [javah])
+AC_CHECK_PROGS([JAVAC], [javac])
 
 # try to guess where JNI headers might be
 # (partially inspired by Don Anderson's AC_JNI_INCLUDE_DIR)
@@ -23,10 +23,10 @@ AC_ARG_VAR([JNI_CFLAGS], [C compiler flags for JNI])
 if test "x$JNI_CFLAGS" = "x"; then
     if test "x$JAVA_HOME" = "x" && test "x$host_alias" = "x$build_alias"; then
         # If JAVA_HOME not set, and we are not cross-compiling, try to
-        # infer it from the location of 'javah' (after following
+        # infer it from the location of 'javac' (after following
         # symlinks.)
-        AC_PATH_PROG([_JAVAH], [$JAVAH])
-        _cur=$_JAVAH
+        AC_PATH_PROG([_JAVAC], [$JAVAC])
+        _cur=$_JAVAC
         while ls -ld "$_cur" 2>/dev/null | grep " -> " >/dev/null; do
             AC_MSG_CHECKING(symlink for $_cur)
             _slink=`ls -ld "$_cur" | sed 's/.* -> //'`

--- a/dependencies/jni/rdsampjni.c
+++ b/dependencies/jni/rdsampjni.c
@@ -18,7 +18,7 @@ To get field signatures for the JNI API, run
 #include <stdio.h>
 #include <wfdb/wfdb.h>
 #include <stdlib.h>
-#include "org_physionet_wfdb_jni_Rdsamp.h"
+//#include "org_physionet_wfdb_jni_Rdsamp.h"
 
 long nSamples=0;
 double fs;


### PR DESCRIPTION
The `javah` tool has been removed since OpenJDK... 9, I think?  We don't really need it, so do without it.
