### PR TITLE
Test suite improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ check-%:
 	 "pkg load signal; \
 	  addpath('$$mcodedir'); \
 	  confirm_recursive_rmdir(0); \
-	  [tests,pass,perf]=test_$*(); \
-	  exit(tests < pass)"
+	  [tests,pass,perf]=test_$*(1); \
+	  exit(pass < tests)"
 
 jartest: mcode/$(JAR7_NAME) unit-test.zip
 	cd mcode; \

--- a/UnitTests/test_wrapper.m
+++ b/UnitTests/test_wrapper.m
@@ -38,8 +38,21 @@ for n=1:tests
         pass=pass+1;
     catch
         fprintf(['\t****Failed test: %s\n'],num2str(n));
-        if(verbose)
-            display(['Last error: ' lasterr]);
+
+        display(['Last error: ' lasterr]);
+        if(exist('lasterror'))
+            err=lasterror;
+            for m=1:length(err.stack)
+                if(isfield(err.stack(m),'column'))
+                    colstr=[', column ' num2str(err.stack(m).column)];
+                else
+                    colstr='';
+                end
+                display([' in ' err.stack(m).name ...
+                         ' (' err.stack(m).file ...
+                         ', line ' num2str(err.stack(m).line) ...
+                         colstr ')']);
+            end
         end
     end
 end


### PR DESCRIPTION
Some small fixes to the test suite (`make check`, `make check-*`):

- When running a single test case (`make check-rdsamp`), enable verbose mode to give more information about what the test is doing.  Ensure that the command fails if there is an error.

- When a test does fail, show the actual stack trace (`lasterror`) and not just the error message (which is little use for debugging.)
