### PR TITLE
Avoid use of java2mat

### DIFF
--- a/mcode/ann2rr.m
+++ b/mcode/ann2rr.m
@@ -82,11 +82,7 @@ end
 wfdb_argument{end+1}='-V';
 
 data=javaWfdbExec.execToDoubleArray(wfdb_argument);
-if(config.inOctave)
-    data=java2mat(data);
-end
+data=wfdbjava2mat(data);
 for n=1:nargout
     eval(['varargout{n}=' outputs{n} ';']);
 end
-
-

--- a/mcode/corrint.m
+++ b/mcode/corrint.m
@@ -264,7 +264,7 @@ javaWfdbExec.setArguments(wfdb_argument);
 
 if(config.inOctave)
     x=cellstr(num2str(x));
-    x=java2mat(javaWfdbExec.execWithStandardInput(x));
+    x=javaWfdbExec.execWithStandardInput(x);
     Nx=x.size;
     out=cell(Nx,1);
     for n=1:Nx

--- a/mcode/dfa.m
+++ b/mcode/dfa.m
@@ -108,7 +108,7 @@ javaWfdbExec.setArguments(wfdb_argument);
 
 if(config.inOctave)
     x=cellstr(num2str(x));
-    x=java2mat(javaWfdbExec.execWithStandardInput(x));
+    x=javaWfdbExec.execWithStandardInput(x);
     Nx=x.size;
     out=cell(Nx,1);
     for n=1:Nx

--- a/mcode/msentropy.m
+++ b/mcode/msentropy.m
@@ -158,7 +158,7 @@ javaWfdbExec.setArguments(wfdb_argument);
 
 if(config.inOctave)
     x=cellstr(num2str(x));
-    x=java2mat(javaWfdbExec.execWithStandardInput(x));
+    x=javaWfdbExec.execWithStandardInput(x);
     Nx=x.size;
     out=cell(Nx,1);
     for n=1:Nx

--- a/mcode/rdann.m
+++ b/mcode/rdann.m
@@ -167,9 +167,7 @@ if(nargout ==1)
     %annotation values
     wfdb_argument{end+1}='-e'; % Ensure first column is just elapsed time so it can be skipped. 
     ann=javaWfdbExec.execToDoubleArray(wfdb_argument);
-    if(config.inOctave)
-        ann=java2mat(ann);
-    end
+    ann=wfdbjava2mat(ann);
 else
     
     %TODO: Improve the parsing of data. To avoid doing this at the ML wrapper

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -194,7 +194,7 @@ switch rawUnits
         %try
             %Channeles are returned in interleaved fashion, in a single
             %array
-            data=double(conv_matrix(javaWfdbRdsamp.exec(wfdb_argument)));
+            data=double(wfdbjava2mat(javaWfdbRdsamp.exec(wfdb_argument)));
         %catch
         %    javaWfdbRdsamp.reset();%Free JNI resources    
         %    error(['Could not find record: ' recordName '. Search path is set to: ''' config.WFDB_PATH '''']); 
@@ -202,7 +202,7 @@ switch rawUnits
         if(isempty(data))
            error(['Could not find record: ' recordName '. Search path is set to: ''' config.WFDB_PATH '''']); 
         end
-        baseline=double(conv_matrix(javaWfdbRdsamp.getBaseline));
+        baseline=double(wfdbjava2mat(javaWfdbRdsamp.getBaseline));
         gain=javaWfdbRdsamp.getGain;
         Fs=double(javaWfdbRdsamp.getFs);
         N=javaWfdbRdsamp.getNSamples;
@@ -248,9 +248,7 @@ switch rawUnits
         error(['Unknown rawUnits option: ' num2str(rawUnits)]);
 end
 
-if(config.inOctave)
-    data=conv_matrix(data);
-end
+data=wfdbjava2mat(data);
 
 if(rawUnits ~=0)
     %Remap variables to output variables (if not using JNI interface)
@@ -294,21 +292,4 @@ for n=1:nargout
     end
 end
 
-end
-
-% Convert a Java array into a matrix.
-function matrix = conv_matrix(array)
-    if(isnumeric(array))
-        matrix=array;
-    else
-        matrix=java2mat(array);
-        if(~isnumeric(matrix))
-            if(exist('java_matrix_autoconversion','builtin'))
-                java_matrix_autoconversion(1,'local');
-            else
-                java_convert_matrix(1,'local');
-            end
-            matrix=java2mat(javaObject('org.octave.Matrix',array));
-        end
-    end
 end

--- a/mcode/tach.m
+++ b/mcode/tach.m
@@ -82,9 +82,7 @@ if(~isempty(ouputSize))
 end
 
 data=javaWfdbExec.execToDoubleArray(wfdb_argument);
-if(config.inOctave)
-    data=java2mat(data);
-end
+data=wfdbjava2mat(data);
 for n=1:nargout
         eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/mcode/visgraph.m
+++ b/mcode/visgraph.m
@@ -72,7 +72,7 @@ end
 
 if(config.inOctave)
     x=cellstr(num2str(x));
-    x=java2mat(javaWfdbExec.execWithStandardInput(x));
+    x=javaWfdbExec.execWithStandardInput(x);
     Nx=x.size;
     out=cell(Nx,1);
     for n=1:Nx

--- a/mcode/wfdbjava2mat.m
+++ b/mcode/wfdbjava2mat.m
@@ -1,0 +1,36 @@
+function matrix = wfdbjava2mat(array)
+%
+% [matrix]=wfdbjava2mat(array)
+%
+% This function takes a one-dimensional or two-dimensional array of
+% Java values, and converts it to a matrix or vector. This conversion
+% is automatic and implicit in Matlab and is sometimes automatic in
+% Octave (depending on the data type and dimensionality) but in other
+% cases an explicit conversion is needed.
+
+if(isnumeric(array))
+    matrix=array;
+else
+    if(exist('java_matrix_autoconversion','builtin'))
+        java_matrix_autoconversion(1,'local');
+    else
+        java_convert_matrix(1,'local');
+    end
+
+    if(exist('__java2mat__','builtin'))
+        matrix=builtin('__java2mat__',array);
+    else
+        matrix=java2mat(array);
+    end
+
+    if(~isnumeric(matrix))
+        matrix=javaObject('org.octave.Matrix',array);
+        if(exist('__java2mat__','builtin'))
+            matrix=builtin('__java2mat__',matrix);
+        else
+            matrix=java2mat(matrix);
+        end
+    end
+end
+
+end


### PR DESCRIPTION
The java2mat function has been removed in Octave 6.0; work around this by defining a wrapper `wfdbjava2mat`.                  

This will only work (and is only needed) for numeric data.  As far as I know, `java2mat` has always been a no-op for string data.
