### PR TITLE
Allow changing configuration dynamically

### DIFF
--- a/mcode/ann2rr.m
+++ b/mcode/ann2rr.m
@@ -50,10 +50,7 @@ function varargout=ann2rr(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('ann2rr');
-end
+[javaWfdbExec,config]=getWfdbClass('ann2rr');
 
 %Set default pararamter values
 inputs={'recordName','annotator','N','N0','consecutiveOnly'};

--- a/mcode/bxb.m
+++ b/mcode/bxb.m
@@ -91,10 +91,7 @@ function varargout=bxb(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('bxb');
-end
+javaWfdbExec=getWfdbClass('bxb');
 
 %Set default pararamter values
 inputs={'recName','refAnn','testAnn','reportFile','beginTime','stopTime','matchWindow'};

--- a/mcode/corrint.m
+++ b/mcode/corrint.m
@@ -197,10 +197,7 @@ function varargout=corrint(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('corrint');
-end
+[javaWfdbExec,config]=getWfdbClass('corrint');
 
 %Set default pararamter values
 inputs={'x','embeddedDim','timeLag','timeStep','distanceThreshold','neighboorSize','estimationMode','findScaling'};

--- a/mcode/dfa.m
+++ b/mcode/dfa.m
@@ -66,11 +66,7 @@ function [ln,lf]=dfa(varargin)
 
 %endOfHelp
 
-
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('dfa');
-end
+[javaWfdbExec,config]=getWfdbClass('dfa');
 
 %Set default pararamter values
 inputs={'x','p','integrateFlag','minBoxSize','maxBoxSize','slideWindowFlag'};

--- a/mcode/ecgpuwave.m
+++ b/mcode/ecgpuwave.m
@@ -104,10 +104,7 @@ function ecgpuwave(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('ecgpuwave');
-end
+javaWfdbExec=getWfdbClass('ecgpuwave');
 
 %Set default pararamter values
 inputs={'recordName','annFileName','startTime','stopTime','qrsAnn','pflag','signalList'};

--- a/mcode/getWfdbClass.m
+++ b/mcode/getWfdbClass.m
@@ -14,6 +14,8 @@
 
 %endOfHelp
 
+persistent classCache;
+
 %Add classes to dynamic path
 [~,config]=wfdbloadlib;
 
@@ -26,8 +28,14 @@ for n=1:nargin
 end
 
 %Load the Java class in memory if it has not been loaded yet
-%with system wide parameters defined by wfdbloadlib.m
-javaWfdbExec=javaObject('org.physionet.wfdb.Wfdbexec',commandName,config.WFDB_CUSTOMLIB);
+if(isfield(classCache,commandName))
+    javaWfdbExec=classCache.(commandName);
+else
+    javaWfdbExec=javaObject('org.physionet.wfdb.Wfdbexec',commandName,config.WFDB_CUSTOMLIB);
+    classCache.(commandName)=javaWfdbExec;
+end
+
+%Set system-wide parameters defined by wfdbloadlib.m
 javaWfdbExec.setInitialWaitTime(config.NETWORK_WAIT_TIME);
 javaWfdbExec.setLogLevel(config.DEBUG_LEVEL);
 javaWfdbExec.setWFDB_PATH(config.WFDB_PATH);

--- a/mcode/getWfdbClass.m
+++ b/mcode/getWfdbClass.m
@@ -14,12 +14,8 @@
 
 %endOfHelp
 
-mlock;
-persistent config
-if(isempty(config))
-    %Add classes to dynamic path
-    [~,config]=wfdbloadlib;
-end
+%Add classes to dynamic path
+[~,config]=wfdbloadlib;
 
 inputs={'commandName'};
 outputs={'javaWfdbExec','config'};

--- a/mcode/gqrs.m
+++ b/mcode/gqrs.m
@@ -71,10 +71,7 @@ function varargout=gqrs(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('gqrs');
-end
+javaWfdbExec=getWfdbClass('gqrs');
 
 %Set default pararamter values
 inputs={'recordName','N','N0','signal','threshold','outputName','highResolution'};

--- a/mcode/lomb.m
+++ b/mcode/lomb.m
@@ -68,10 +68,7 @@ function varargout=lomb(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('lomb');
-end
+javaWfdbExec=getWfdbClass('lomb');
 
 %Set default pararamter values
 %[Pxx,F]

--- a/mcode/mrgann.m
+++ b/mcode/mrgann.m
@@ -60,10 +60,7 @@ function mrgann(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('mrgann');
-end
+javaWfdbExec=getWfdbClass('mrgann');
 
 %Set default pararamter values
 % [ann,type,subtype,chan,num]=rdann(recordName,annotator,C,N,N0)

--- a/mcode/msentropy.m
+++ b/mcode/msentropy.m
@@ -86,10 +86,8 @@ function varargout=msentropy(varargin)
 % See also SURROGATE, DFA, WFDBDESC, PHYSIONETDB, RDANN, ANN2RR, MAPRECORD
 
 %endOfHelp
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('mse');
-end
+
+[javaWfdbExec,config]=getWfdbClass('mse');
 
 %Set default pararamter values
 inputs={'x','dn','dm','dr','N','N0','minM','maxM','maxScale','minR','maxR'};

--- a/mcode/mxm.m
+++ b/mcode/mxm.m
@@ -57,12 +57,7 @@ function varargout=mxm(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('mxm');
-end
+javaWfdbExec=getWfdbClass('mxm');
 
 %Set default pararamter values
 inputs={'recName','refAnn','testAnn','reportFile',...

--- a/mcode/physionetdb.m
+++ b/mcode/physionetdb.m
@@ -61,12 +61,9 @@ function varargout=physionetdb(varargin)
 
 %endOfHelp
 
-persistent isloaded config
+%Add classes to path
+[isloaded,config]=wfdbloadlib;
 
-if(isempty(isloaded) || ~isloaded)
-    %Add classes to path
-    [isloaded,config]=wfdbloadlib;
-end
 %URL to PhysioBank database in PhysioNet
 PHYSIONET_URL=config.CACHE_SOURCE;
 inputs={'db_name','DoBatchDownload','webBrowser'};

--- a/mcode/rdann.m
+++ b/mcode/rdann.m
@@ -98,11 +98,8 @@ function varargout=rdann(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('rdann');
-    [~,config]=wfdbloadlib;
-end
+javaWfdbExec=getWfdbClass('rdann');
+[~,config]=wfdbloadlib;
 
 %Set default pararamter values
 % [ann, anntype, subtype, chan, num, comments] = rdann(recordName, annotator, C, N, N0, AT)

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -83,10 +83,7 @@ function varargout=rdsamp(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('rdsamp');
-end
+[javaWfdbExec,config]=getWfdbClass('rdsamp');
 
 %Set default pararamter values
 inputs={'recordName','signalList','N','N0','rawUnits','highResolution'};

--- a/mcode/snip.m
+++ b/mcode/snip.m
@@ -55,11 +55,8 @@ function varargout=snip(varargin)
 
 
 %endOfHelp
-persistent javaWfdbExec
 
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('snip');
-end
+javaWfdbExec=getWfdbClass('snip');
 
 %Set default pararamter values
 

--- a/mcode/sortann.m
+++ b/mcode/sortann.m
@@ -46,10 +46,8 @@ function varargout=sortann(varargin)
 % See also RDANN 
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('sortann');
-end
+
+javaWfdbExec=getWfdbClass('sortann');
 
 %Set default pararamter values
 inputs={'recName','annName','beginTime','stopTime','outFile'};

--- a/mcode/sqrs.m
+++ b/mcode/sqrs.m
@@ -58,10 +58,7 @@ function varargout=sqrs(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('sqrs');
-end
+javaWfdbExec=getWfdbClass('sqrs');
 
 %Set default pararamter values
 inputs={'recordName','annotator','N','N0','signal','threshold'};

--- a/mcode/sumann.m
+++ b/mcode/sumann.m
@@ -43,10 +43,8 @@ function varargout=sumann(varargin)
 % See also RDANN, MXM, WFDBTIME, BXB
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('sumann');
-end
+
+javaWfdbExec=getWfdbClass('sumann');
 
 %Set default pararamter values
 inputs={'recName','annName','stopTime','qrsAnnotationsOnly'};

--- a/mcode/tach.m
+++ b/mcode/tach.m
@@ -50,10 +50,8 @@ function varargout=tach(varargin)
 %plot(hr);grid on;hold on
 
 %endOfHelp
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('tach');
-end
+
+[javaWfdbExec,config]=getWfdbClass('tach');
 
 %Set default pararamter values
 inputs={'recordName','annotator','N','N0','ouputSize'};

--- a/mcode/visgraph.m
+++ b/mcode/visgraph.m
@@ -54,10 +54,7 @@ function varargout=visgraph(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('visibility');
-end
+[javaWfdbExec,config]=getWfdbClass('visibility');
 
 %Set default pararamter values
 inputs={'x'};

--- a/mcode/wabp.m
+++ b/mcode/wabp.m
@@ -79,10 +79,8 @@ function varargout=wabp(varargin)
 %
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    [javaWfdbExec]=getWfdbClass('wabp');
-end
+
+[javaWfdbExec]=getWfdbClass('wabp');
 
 %Set default pararamter values
 inputs={'recName','beginTime','stopTime','resample','signal'};

--- a/mcode/wfdb2mat.m
+++ b/mcode/wfdb2mat.m
@@ -50,10 +50,7 @@ function wfdb2mat(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('wfdb2mat');
-end
+[javaWfdbExec,config]=getWfdbClass('wfdb2mat');
 
 %Set default pararameter values
 inputs={'recordName','signalList','N','N0'};

--- a/mcode/wfdbdesc.m
+++ b/mcode/wfdbdesc.m
@@ -85,10 +85,7 @@ function varargout=wfdbdesc(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('wfdbdesc');
-end
+[javaWfdbExec,config]=getWfdbClass('wfdbdesc');
 
 %Set default pararamter values
 inputs={'recordName'};

--- a/mcode/wfdbdownload.m
+++ b/mcode/wfdbdownload.m
@@ -58,11 +58,7 @@ for n=1:nargin
     end
 end
 
-persistent config 
-
-if(isempty(config))
-    [~,config]=wfdbloadlib;
-end
+[~,config]=wfdbloadlib;
 
 %Check if file exist  already, if exists in CACHE, exit
 file_info=dir([config.CACHE_DEST recordName '.*']);

--- a/mcode/wfdbexec.m
+++ b/mcode/wfdbexec.m
@@ -80,11 +80,9 @@ function varargout=wfdbexec(varargin)
 
 %endOfHelp
 logLevel=[];
-persistent config
 
-if(isempty(config))
-    [~,config]=wfdbloadlib;
-end
+[~,config]=wfdbloadlib;
+
 if(nargin==0)
     %With no arguments passed in, we provide the user a list of native
     %commands available for this OS.

--- a/mcode/wfdbloadlib.m
+++ b/mcode/wfdbloadlib.m
@@ -75,6 +75,13 @@ networkWaitTime=1000;
 
 %%%% END OF SYSTEM WIDE CONFIGURATION PARAMETERS
 
+%If called without arguments, keep the current configuration.
+%Explicit arguments override the default settings above.
+if(~isempty(config))
+    debugLevel=config.DEBUG_LEVEL;
+    networkWaitTime=config.NETWORK_WAIT_TIME;
+end
+
 inputs={'debugLevel','networkWaitTime'};
 for n=1:nargin
     if(~isempty(varargin{n}))
@@ -146,8 +153,6 @@ if(isempty(config))
         config.MATLAB_PATH=strrep(which('wfdbloadlib'),'wfdbloadlib.m','');
         wver=regexp(wfdb_path,fsep,'split');
         config.WFDB_JAVA_VERSION=wver{end};
-        config.DEBUG_LEVEL=debugLevel;
-        config.NETWORK_WAIT_TIME=networkWaitTime;
         config.MATLAB_ARCH=computer('arch');
         %Remove empty spaces from arch name
         del=strfind(config.osName,' ');
@@ -199,6 +204,9 @@ if(isempty(config))
     setenv('WFDBCAL',config.WFDBCAL);
 end
 
+%Set dynamic configuration parameters
+config.DEBUG_LEVEL=debugLevel;
+config.NETWORK_WAIT_TIME=networkWaitTime;
 
 outputs={'isloaded','config'};
 for n=1:nargout

--- a/mcode/wfdbtime.m
+++ b/mcode/wfdbtime.m
@@ -42,10 +42,8 @@ function varargout=wfdbtime(varargin)
 %
 
 %endOfHelp
-persistent javaWfdbExec config
-if(isempty(javaWfdbExec))
-    [javaWfdbExec,config]=getWfdbClass('wfdbtime');
-end
+
+[javaWfdbExec,config]=getWfdbClass('wfdbtime');
 
 %Set default pararamter values
 inputs={'recordName','samples'};

--- a/mcode/wqrs.m
+++ b/mcode/wqrs.m
@@ -78,10 +78,8 @@ function varargout=wqrs(varargin)
 %wqrs('challenge/2013/set-a/a01');
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('wqrs');
-end
+
+javaWfdbExec=getWfdbClass('wqrs');
 
 %Set default pararamter values
 inputs={'recordName','N','N0','signal','threshold', ...

--- a/mcode/wrann.m
+++ b/mcode/wrann.m
@@ -87,10 +87,8 @@ function varargout=wrann(varargin)
 %
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('wrann');
-end
+
+javaWfdbExec=getWfdbClass('wrann');
 
 % Set default pararamter values
 inputs={'recordName','annotator','ann','annType','subType','chan','num','comments'};

--- a/mcode/wrsamp.m
+++ b/mcode/wrsamp.m
@@ -74,10 +74,8 @@ function varargout=wrsamp(varargin)
 %
 
 %endOfHelp
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('wrsamp');
-end
+
+javaWfdbExec=getWfdbClass('wrsamp');
 
 %Set default pararamter values
 inputs={'tm','data','fileName','Fs','gain','format'};

--- a/mcode/xform.m
+++ b/mcode/xform.m
@@ -50,12 +50,7 @@ function varargout=snip(varargin)
 
 %endOfHelp
 
-persistent javaWfdbExec
-
-persistent javaWfdbExec
-if(isempty(javaWfdbExec))
-    javaWfdbExec=getWfdbClass('xform');
-end
+javaWfdbExec=getWfdbClass('xform');
 
 %Set default pararamter values
 


### PR DESCRIPTION
For debugging, it's useful to be able to change the log level at any time (i.e., after wfdbloadlib has already been called.)

Before:
```
octave:1> wfdbloadlib
OpenJDK 64-Bit Server VM warning: Archived non-system classes are disabled [...]
octave:2> wfdbloadlib(2)  % this has no effect!
octave:3> [x,y]=rdann('xxxxx','atr')
error: [java] java.lang.ArrayIndexOutOfBoundsException
error: called from
    rdann at line 188 column 8
```

After:
```
octave:1> wfdbloadlib
OpenJDK 64-Bit Server VM warning: Archived non-system classes are disabled [...]
octave:2> wfdbloadlib(2)  % change log level to 2 so we get some useful output
octave:3> [x,y]=rdann('xxxxx','atr')
Jan 12, 2022 3:11:11 PM org.physionet.wfdb.ErrorReader run
WARNING: init: can't open header for record xxxxx
Jan 12, 2022 3:11:11 PM org.physionet.wfdb.ErrorReader run
WARNING: annopen: can't read annotator atr for record xxxxx
error: [java] java.lang.ArrayIndexOutOfBoundsException
error: called from
    rdann at line 185 column 8
```
