### PR TITLE
Updates the ADC res in the mat2wfdb.m 

### DIFF
--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -251,7 +251,7 @@ for m=1:M
     % Header file signal specification lines
     % Should we specify precision of num2str(gain)?
     head_str(m+1)={[fname '.dat ' fmt ' ' num2str(bit_gain) '(' ...
-        num2str(baseline_tmp) ')/' adu{m} ' ' '0 0 ' num2str(tmp_bit1(1)) ' ' num2str(ck_sum) ' 0 ' sg_name{m}]};
+        num2str(baseline_tmp) ')/' adu{m} ' ' num2str(bit_res) ' 0 ' num2str(tmp_bit1(1)) ' ' num2str(ck_sum) ' 0 ' sg_name{m}]};
 end
 if(length(y)<1)
     error(['Converted data is empty. Exiting without saving file...']);


### PR DESCRIPTION
This PR updates the ADC resolution (bits) field to match the input bit resolution.
The format of the signal specification lines in the header can be found here :https://archive.physionet.org/physiotools/wag/header-5.htm
