### PR TITLE
wfdbdownload saves HTML error pages as signal data

### DIFF
--- a/mcode/getWfdbClass.m
+++ b/mcode/getWfdbClass.m
@@ -38,7 +38,14 @@ end
 %Set system-wide parameters defined by wfdbloadlib.m
 javaWfdbExec.setInitialWaitTime(config.NETWORK_WAIT_TIME);
 javaWfdbExec.setLogLevel(config.DEBUG_LEVEL);
-javaWfdbExec.setWFDB_PATH(config.WFDB_PATH);
+%Respect WFDB environment variable if set by the user (e.g. for local
+%datasets), otherwise fall back to the toolbox default path.
+wfdb_env=getenv('WFDB');
+if(~isempty(wfdb_env))
+    javaWfdbExec.setWFDB_PATH(wfdb_env);
+else
+    javaWfdbExec.setWFDB_PATH(config.WFDB_PATH);
+end
 javaWfdbExec.setWFDBCAL(config.WFDBCAL);
 
 for n=1:nargout

--- a/mcode/wfdbdownload.m
+++ b/mcode/wfdbdownload.m
@@ -60,11 +60,15 @@ end
 
 [~,config]=wfdbloadlib;
 
-%Check if file exist  already, if exists in CACHE, exit
-file_info=dir([config.CACHE_DEST recordName '.*']);
+%Check if both .hea and .dat exist in CACHE before skipping download.
+%The original wildcard check (dir(...'.*')) would match if only one file
+%was present (e.g. .dat without .hea), permanently preventing the missing
+%file from being re-downloaded.
+hea_exists=exist([config.CACHE_DEST recordName '.hea'],'file');
+dat_exists=exist([config.CACHE_DEST recordName '.dat'],'file');
 ind=findstr(recordName,'/'); %If empty, not in PhysioBank DB format
 
-if(~isempty(file_info) || isempty(ind) || (config.CACHE==0))
+if((hea_exists && dat_exists) || isempty(ind) || (config.CACHE==0))
     success=-1;
 else
     
@@ -81,15 +85,26 @@ else
         
         %File does not exist on cache, attempt to download from server
         for m=1:M
+            dest_file=[config.CACHE_DEST recordName wfdb_extensions{m}];
             try
             [furl] = urlwrite([config.CACHE_SOURCE recordName wfdb_extensions{m}],...
-                [config.CACHE_DEST recordName wfdb_extensions{m}],'Timeout',timeout);
+                dest_file,'Timeout',timeout);
             if(~isempty(furl))
-                files_saved{end+1}=furl;
-                warning(['Downloaded WFDB cache file: ' furl]);
+                %Verify we didn't download an HTML error page.
+                %PhysioNet returns HTML for 404s and HTTPS redirects,
+                %which urlwrite saves as if it were valid data.
+                fid=fopen(dest_file,'r');
+                header=fread(fid,5,'*char')';
+                fclose(fid);
+                if(strncmpi(header,'<!DOC',5) || strncmpi(header,'<html',5))
+                    delete(dest_file);
+                else
+                    files_saved{end+1}=furl;
+                    warning(['Downloaded WFDB cache file: ' furl]);
+                end
             end
             catch
-               %Do nothing, because some extensions will not exist 
+               %Do nothing, because some extensions will not exist
             end
         end
         success=length(files_saved);

--- a/mcode/wfdbloadlib.m
+++ b/mcode/wfdbloadlib.m
@@ -160,6 +160,10 @@ if(isempty(config))
         
         %Define WFDB Environment variables
         if(isempty(WFDB_PATH))
+            %Check if user has set the WFDB environment variable
+            WFDB_PATH=getenv('WFDB');
+        end
+        if(isempty(WFDB_PATH))
             tmpCache=[config.MATLAB_PATH '..' filesep 'database' filesep];
             WFDB_PATH=['. ' tmpCache ' http://physionet.org/physiobank/database/'];
         end


### PR DESCRIPTION
PhysioNet now returns HTML for some requests (404s, HTTPS redirects
  on newer URL paths). `urlwrite` saves these responses as `.dat`/`.hea`
  files in the toolbox cache. The native binaries then crash trying to
  parse HTML:

      java.lang.NullPointerException
          at org.physionet.wfdb.Wfdbexec.execToDoubleArray(Unknown Source)

  A second issue compounds this: `wfdbdownload` uses a wildcard glob
  (`dir(...'.*')`) to check if a record is cached. If only `.dat` was
  saved and `.hea` failed, the function still thinks the record is
  cached and never retries — permanently breaking that record.

  Additionally, `setenv('WFDB', '/path/to/data .')` is silently ignored
  by `getWfdbClass`, so users cannot point the toolbox at local datasets
  as a workaround.

  **Environment:** MATLAB R2025b, Linux x86_64, wfdb-app-toolbox 0.10.0